### PR TITLE
Add separate REG.sublime-syntax

### DIFF
--- a/INI.sublime-syntax
+++ b/INI.sublime-syntax
@@ -9,7 +9,6 @@ file_extensions:
   - conf
   - inf
   - ini
-  - reg
 
 variables:
   separator: '[=:]'
@@ -17,13 +16,6 @@ variables:
 contexts:
 
   main:
-    - match: ^(?:REGEDIT4|Windows Registry Editor Version 5\.00)\b
-      scope: meta.directive.registry.ini keyword.other.directive.registry.ini
-      set: content
-    - match: ''
-      set: content
-
-  content:
     - include: comment
     - include: section
     - include: mapping

--- a/REG.sublime-syntax
+++ b/REG.sublime-syntax
@@ -1,0 +1,15 @@
+%YAML 1.2
+---
+name: REG
+scope: source.reg
+
+file_extensions:
+  - reg
+
+contexts:
+  main:
+    - match: (?:REGEDIT4|Windows Registry Editor Version 5\.00)\b
+      scope: meta.directive.registry.ini keyword.other.directive.registry.ini
+      set: INI.sublime-syntax
+    - match: ^|(?=\S)
+      set: INI.sublime-syntax

--- a/reg_completions.py
+++ b/reg_completions.py
@@ -5,21 +5,18 @@ import sublime_plugin
 class WindowsRegistryCompletions(sublime_plugin.EventListener):
     def on_query_completions(self, view, prefix, locations):
         pt = locations[0]
-        if not view.match_selector(pt, "source.ini | source.reg"):
-            return None
-        file_name = view.file_name()
-        if not file_name or not file_name.lower().endswith("reg"):
+        if not view.match_selector(pt, "source.reg"):
             return None
         if pt == len(prefix):
-            return [["Windows Registry Editor Version 5.00", "Windows Registry Editor Version 5.00"]]
-        elif view.match_selector(pt - len(prefix) - 1, "punctuation.definition.section.begin.ini | meta.section.ini keyword.operator.arithmetic.ini"):
+            return ["Windows Registry Editor Version 5.00"]
+        elif view.match_selector(pt - len(prefix) - 1, "punctuation.definition.section.begin | meta.section keyword.operator.arithmetic"):
             return (
                 [
-                    ["HKEY_CLASSES_ROOT", "HKEY_CLASSES_ROOT"],
-                    ["HKEY_CURRENT_USER", "HKEY_CURRENT_USER"],
-                    ["HKEY_LOCAL_MACHINE", "HKEY_LOCAL_MACHINE"],
-                    ["HKEY_USERS", "HKEY_USERS"],
-                    ["HKEY_CURRENT_CONFIG", "HKEY_CURRENT_CONFIG"]
+                    ["HKEY_CLASSES_ROOT\tkey", "HKEY_CLASSES_ROOT"],
+                    ["HKEY_CURRENT_USER\tkey", "HKEY_CURRENT_USER"],
+                    ["HKEY_LOCAL_MACHINE\tkey", "HKEY_LOCAL_MACHINE"],
+                    ["HKEY_USERS\tkey", "HKEY_USERS"],
+                    ["HKEY_CURRENT_CONFIG\tkey", "HKEY_CURRENT_CONFIG"]
                 ],
                 sublime.INHIBIT_WORD_COMPLETIONS
             )


### PR DESCRIPTION
This commit adds a dedicated REG.sublime-syntax with `source.reg` scope in order to assign *.reg files a dedicated icon via "A File Icon" without the need of an alias syntax.

The "REGEDIT" patterns are moved to REG.sublime-syntax, too.

Maybe the `dword()` and `hex()` rules could so, too?

#### Background

A File Icon addresses `source.reg` to apply `file_type_registry` icon to all *.reg files. It does so by creating an alias syntax right now.

The PR https://github.com/SublimeText/AFileIcon/pull/31 asks to remove this automatic alias creation in favor of just providing an icon in case https://github.com/robertcollier4/REG is installed.

While this package provides some interesting tools to import a reg files into the registry, its syntax is just garbage and uses odd and wrong scope names.

I guess, I won't use the mentioned REG package but don't want to need to create an alias manually.