### PR TITLE
Include INI syntax context with full relative path

### DIFF
--- a/EditorConfig.sublime-syntax
+++ b/EditorConfig.sublime-syntax
@@ -10,7 +10,7 @@ file_extensions:
 
 contexts:
   main:
-    - include: INI.sublime-syntax#comment
+    - include: Packages/INI/INI.sublime-syntax#comment
     - include: section
     - include: mapping
 
@@ -62,7 +62,7 @@ contexts:
             - - meta_content_scope: meta.mapping.ini
               - match: (?=\S)
                 set:
-                  - INI.sublime-syntax#mapping-value-meta
+                  - Packages/INI/INI.sublime-syntax#mapping-value-meta
                   - mapping-value
               - include: eol-pop
             - - match: =
@@ -70,7 +70,7 @@ contexts:
                 pop: true
         - match: \b(?:indent_style|indent_size|tab_width|end_of_line|charset|trim_trailing_whitespace|insert_final_newline|root)\b
           scope: variable.language.ini
-        - include: INI.sublime-syntax#string
+        - include: Packages/INI/INI.sublime-syntax#string
         - include: eol-pop
 
   mapping-value:
@@ -78,8 +78,8 @@ contexts:
       scope: support.constant.ini
     - match: \b(?i:true|false)\b
       scope: constant.language.ini
-    - include: INI.sublime-syntax#number
-    - include: INI.sublime-syntax#string
+    - include: Packages/INI/INI.sublime-syntax#number
+    - include: Packages/INI/INI.sublime-syntax#string
     - include: eol-pop
 
   eol-pop:


### PR DESCRIPTION
## Issue

![image](https://user-images.githubusercontent.com/6594915/183558962-d9d23d3f-77f3-4f3e-b8ad-0b012ada1dae.png)

## Cause

When every plugin thinks it's a good ideal to provide a INI syntax, it becomes a chaos.

I uses [EditorConfig](https://packagecontrol.io/packages/EditorConfig) file and [DoxyDoxygen](https://packagecontrol.io/packages/DoxyDoxygen%20(evolution)) plugin. Now an interesting thing happens...

Although this `INI` package provides `EditorConfig` syntax, but it doesn't provide (it shouldn't indeed) functionality to make ST respect `.editorconfig` settings so I still have to install the `EditorConfig` plugin, which provides its own `INI` and `EditorConfig` syntax.

As for (close-sourced) `DoxyDoxygen`, it considers the `INI` syntax it bundles is superior so I don't have to use any other ones. (https://github.com/20Tauri/DoxyDoxygen/issues/150)

With those plugins above, now interestingly ST considers the `INI.sublime-syntax` used in `include` statements in this plugin is to include the `INI.sublime-syntax` in the `EditorConfig` package and results in errors.

## Solution

The PR won't solve any INI ecosystem chaos but just referenece a syntax context by full relative path so that ST won't reference to a wrong nonexistent context.